### PR TITLE
Enhance Org Manager UI with Scratch Org creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyline-devops",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyline-devops",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
         "@salesforce-ux/design-system": "^2.25.3",
         "@types/uuid": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@lwc/module-resolver": "^8.8.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
-    "@types/vscode": "^1.99.1",
+    "@types/vscode": "^1.95.0",
     "@typescript-eslint/eslint-plugin": "^6.4.1",
     "@typescript-eslint/parser": "^6.4.1",
     "@vscode/test-electron": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "A Salesforce DevOps Tool",
   "icon": "images/Skyline_logo.png",
   "publisher": "mitchspano",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/mitchspano/skyline"
   },
   "engines": {
-    "vscode": "^1.99.0"
+    "vscode": "^1.95.0"
   },
   "categories": [
     "Other"

--- a/src/modules/s/orgManager/orgManager.html
+++ b/src/modules/s/orgManager/orgManager.html
@@ -17,14 +17,23 @@
 <template>
   <div class="slds-p-around_medium slds-text-color_default">
     <lightning-card title="Org Manager">
-      <lightning-button
-        label="Authenticate New Org"
-        variant="brand"
-        onclick={handleAuthOrg}
-        disabled={isLoading}
-        slot="actions"
-      >
-      </lightning-button>
+      <div slot="actions">
+        <lightning-button
+          label="Create Scratch Org"
+          variant="brand"
+          onclick={handleCreateScratchOrg}
+          disabled={isLoading}
+          class="slds-m-right_x-small"
+        >
+        </lightning-button>
+        <lightning-button
+          label="Authenticate New Org"
+          variant="brand"
+          onclick={handleAuthOrg}
+          disabled={isLoading}
+        >
+        </lightning-button>
+      </div>
 
       <template if:true={error}>
         <div
@@ -153,5 +162,14 @@
         </template>
       </template>
     </lightning-card>
+
+    <template if:true={showScratchOrgModal}>
+      <s-scratch-org-modal
+        dev-hubs={devHubs}
+        definition-file-options={definitionFileOptions}
+        onclose={handleScratchOrgModalClose}
+        oncreate={handleScratchOrgCreate}
+      ></s-scratch-org-modal>
+    </template>
   </div>
 </template>

--- a/src/modules/s/scratchOrgModal/scratchOrgModal.css
+++ b/src/modules/s/scratchOrgModal/scratchOrgModal.css
@@ -1,0 +1,28 @@
+:host {
+  position: fixed !important;
+  top: 0; left: 0; right: 0; bottom: 0;
+  z-index: 7000 !important;
+  display: block;
+}
+.slds-modal {
+  display: block;
+  z-index: 7001 !important;
+}
+.slds-modal__container {
+  max-width: 70rem;
+  width: 70%;
+  z-index: 7002 !important;
+}
+.slds-form-element {
+  margin-bottom: 1rem;
+}
+.slds-form-element__label {
+  font-weight: 500;
+}
+.slds-input,
+.slds-select {
+  width: 100%;
+}
+.slds-backdrop {
+  z-index: 7000 !important;
+} 

--- a/src/modules/s/scratchOrgModal/scratchOrgModal.html
+++ b/src/modules/s/scratchOrgModal/scratchOrgModal.html
@@ -1,0 +1,82 @@
+<template>
+  <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open" aria-modal="true" aria-labelledby="modal-heading-01">
+    <div class="slds-modal__container">
+      <!-- Modal Header -->
+      <header class="slds-modal__header">
+        <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse" title="Close" onclick={handleCancel}>
+          <lightning-icon icon-name="utility:close" alternative-text="Close" variant="inverse" size="small"></lightning-icon>
+          <span class="slds-assistive-text">Close</span>
+        </button>
+        <h2 id="modal-heading-01" class="slds-modal__title slds-hyphenate">Create Scratch Org</h2>
+      </header>
+
+      <!-- Modal Body -->
+      <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
+        <template if:true={error}>
+          <div class="slds-notify slds-notify_alert slds-alert_error" role="alert">
+            <span class="slds-assistive-text">error</span>
+            <h2>{error}</h2>
+          </div>
+        </template>
+
+        <div class="slds-form slds-form_horizontal">
+          <!-- Dev Hub Selection -->
+          <div class="slds-form-element">
+            <label class="slds-form-element__label" for="devHub">Dev Hub</label>
+            <div class="slds-form-element__control">
+              <div class="slds-select_container">
+                <select id="devHub" class="slds-select" onchange={handleDevHubChange}>
+                  <option value="">Select a Dev Hub</option>
+                  <template for:each={devHubOptions} for:item="option">
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  </template>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <!-- Org Alias -->
+          <div class="slds-form-element">
+            <label class="slds-form-element__label" for="orgAlias">Org Alias</label>
+            <div class="slds-form-element__control">
+              <input type="text" id="orgAlias" class="slds-input" value={orgAlias} onchange={handleAliasChange} />
+            </div>
+          </div>
+
+          <!-- Definition File -->
+          <div class="slds-form-element">
+            <label class="slds-form-element__label" for="definitionFile">Definition File</label>
+            <div class="slds-form-element__control">
+              <template if:true={hasDefinitionFileOptions}>
+                <select id="definitionFile" class="slds-select" value={definitionFile} onchange={handleDefinitionFileChange}>
+                  <template for:each={definitionFileOptions} for:item="file">
+                    <option key={file} value={file}>{file}</option>
+                  </template>
+                </select>
+              </template>
+              <template if:false={hasDefinitionFileOptions}>
+                <div class="slds-text-color_error">No valid definition files found in workspace.</div>
+              </template>
+            </div>
+          </div>
+
+          <!-- Duration (Days) -->
+          <div class="slds-form-element">
+            <label class="slds-form-element__label" for="days">Duration (Days)</label>
+            <div class="slds-form-element__control">
+              <input type="number" id="days" class="slds-input" min="1" max="30" value={days} onchange={handleDaysChange} />
+            </div>
+            <div class="slds-form-element__help">Enter a value from 1 to 30</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Modal Footer -->
+      <footer class="slds-modal__footer">
+        <button class="slds-button slds-button_neutral" onclick={handleCancel}>Cancel</button>
+        <button class="slds-button slds-button_brand" onclick={handleSubmit} disabled={isCreateDisabled}>Create</button>
+      </footer>
+    </div>
+    <div class="slds-backdrop slds-backdrop_open"></div>
+  </section>
+</template> 

--- a/src/modules/s/scratchOrgModal/scratchOrgModal.ts
+++ b/src/modules/s/scratchOrgModal/scratchOrgModal.ts
@@ -1,0 +1,106 @@
+import { LightningElement, api, track } from "lwc";
+import { OrgInfo } from "../orgManager/orgManager";
+
+export default class ScratchOrgModal extends LightningElement {
+  @api devHubs: OrgInfo[] = [];
+  @api definitionFileOptions: string[] = [];
+  @track selectedDevHub: string = "";
+  @track orgAlias: string = "";
+  @track definitionFile: string = "";
+  @track days: number = 7;
+  @track isLoading = false;
+  @track error: string | null = null;
+
+  get hasDevHubs() {
+    return this.devHubs.length > 0;
+  }
+
+  get devHubOptions() {
+    return this.devHubs.map(hub => ({
+      label: `${hub.alias} (${hub.username})`,
+      value: hub.alias
+    }));
+  }
+
+  get hasDefinitionFileOptions() {
+    return this.definitionFileOptions && this.definitionFileOptions.length > 0;
+  }
+
+  handleDevHubChange(event: Event) {
+    this.selectedDevHub = (event.target as HTMLSelectElement).value;
+  }
+
+  handleAliasChange(event: Event) {
+    this.orgAlias = (event.target as HTMLInputElement).value;
+  }
+
+  handleDefinitionFileChange(event: Event) {
+    this.definitionFile = (event.target as HTMLSelectElement).value;
+  }
+
+  handleDaysChange(event: Event) {
+    const value = parseInt((event.target as HTMLInputElement).value, 10);
+    if (!isNaN(value) && value >= 1 && value <= 30) {
+      this.days = value;
+      this.error = null;
+    } else {
+      this.error = "Days must be between 1 and 30";
+    }
+  }
+
+  handleCancel() {
+    this.dispatchEvent(new CustomEvent("close"));
+  }
+
+  handleSubmit() {
+    if (!this.selectedDevHub) {
+      this.error = "Please select a Dev Hub";
+      return;
+    }
+
+    if (!this.orgAlias) {
+      this.error = "Please enter an org alias";
+      return;
+    }
+
+    if (!this.definitionFile) {
+      this.error = "Please select a definition file";
+      return;
+    }
+
+    if (!this.days || this.days < 1 || this.days > 30) {
+      this.error = "Days must be between 1 and 30";
+      return;
+    }
+
+    this.dispatchEvent(
+      new CustomEvent("create", {
+        detail: {
+          devHub: this.selectedDevHub,
+          alias: this.orgAlias,
+          definitionFile: this.definitionFile,
+          days: this.days
+        }
+      })
+    );
+  }
+
+  connectedCallback() {
+    // Set default definition file if options exist
+    if (this.hasDefinitionFileOptions && !this.definitionFile) {
+      this.definitionFile = this.definitionFileOptions[0];
+    }
+  }
+
+  get isCreateDisabled() {
+    return !(
+      this.selectedDevHub &&
+      this.orgAlias &&
+      this.definitionFile &&
+      this.days &&
+      this.days >= 1 &&
+      this.days <= 30 &&
+      !this.error
+    );
+  }
+} 


### PR DESCRIPTION
- Bumped package version to 0.0.5 in package.json and package-lock.json.
- Added a new Scratch Org creation modal in the Org Manager UI, allowing users to create scratch orgs with selected Dev Hub, org alias, definition file, and duration.
- Implemented error handling and validation for the Scratch Org creation process.
- Introduced new CSS and HTML files for the Scratch Org modal component.

This update improves the user experience by providing a streamlined interface for managing scratch orgs.