### PR TITLE
Remove Duplicate Publish Action Runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: Publish Extension
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2 # We need the previous commit to compare versions
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install vsce
+        run: npm install -g @vscode/vsce
+
+      - name: Install ovsx
+        run: npm install -g ovsx
+
+      - name: Check version change
+        id: version_check
+        run: |
+          PREV_VERSION=$(git show HEAD^:package.json | jq -r .version)
+          CURRENT_VERSION=$(jq -r .version package.json)
+
+          if [ "$PREV_VERSION" != "$CURRENT_VERSION" ]; then
+            echo "Version changed from $PREV_VERSION to $CURRENT_VERSION"
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version unchanged ($CURRENT_VERSION)"
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish to Open VSX
+        if: steps.version_check.outputs.version_changed == 'true'
+        run: ovsx publish -p ${{ secrets.OPEN_VSX_TOKEN }}
+
+      - name: Publish to VS Code Marketplace
+        if: steps.version_check.outputs.version_changed == 'true'
+        run: vsce publish -p ${{ secrets.VSCE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,15 +4,10 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [closed]
-    branches:
-      - main
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,15 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [closed]
+    branches:
+      - main
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Updates the publish workflow to only trigger on push events to the main branch. This change removes the `pull_request` trigger, so the workflow will now run just once per merge (or direct push) to main, preventing duplicate runs.