### PR TITLE
Settings and help

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -48,9 +48,17 @@ export function activate(context: vscode.ExtensionContext) {
         (message) => {
           if (message.openSettings) {
             // Open VSCode settings for the Skyline extension
-            vscode.commands.executeCommand('workbench.action.openSettings', '@ext:mitchspano.skyline-devops');
+            vscode.commands.executeCommand(
+              "workbench.action.openSettings",
+              "@ext:mitchspano.skyline-devops"
+            );
           } else {
-            execute(panel, message.command, message.elementId, message.requestId);
+            execute(
+              panel,
+              message.command,
+              message.elementId,
+              message.requestId
+            );
           }
         },
         undefined,

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -36,7 +36,8 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.ViewColumn.One, // Editor column to show the new webview panel in.
         {
           enableScripts: true,
-          retainContextWhenHidden: true
+          retainContextWhenHidden: true,
+          localResourceRoots: [context.extensionUri]
         }
       );
       panel.webview.html = getWebviewContent(
@@ -45,7 +46,12 @@ export function activate(context: vscode.ExtensionContext) {
       );
       panel.webview.onDidReceiveMessage(
         (message) => {
-          execute(panel, message.command, message.elementId, message.requestId);
+          if (message.openSettings) {
+            // Open VSCode settings for the Skyline extension
+            vscode.commands.executeCommand('workbench.action.openSettings', '@ext:mitchspano.skyline-devops');
+          } else {
+            execute(panel, message.command, message.elementId, message.requestId);
+          }
         },
         undefined,
         context.subscriptions

--- a/extension/src/modules/s/app/app.ts
+++ b/extension/src/modules/s/app/app.ts
@@ -23,7 +23,6 @@
  */
 
 import { LightningElement, track } from "lwc";
-import CLIElement from "../cliElement/cliElement";
 import { v4 as uuidv4 } from "uuid";
 
 declare global {
@@ -127,6 +126,18 @@ export default class App extends LightningElement {
         );
       }
     });
+  }
+
+  /**
+   * Sends a message to the VS Code extension without expecting a response.
+   * @param message The message to send.
+   */
+  static sendMessage(message: any): void {
+    App.vscode.postMessage(message);
+
+    if (App.isDebugMode()) {
+      console.log(`[DEBUG] Sending message:`, message);
+    }
   }
 
   /**

--- a/extension/src/modules/s/header/header.html
+++ b/extension/src/modules/s/header/header.html
@@ -28,8 +28,8 @@
               <lightning-icon
                 icon-name="utility:builder"
                 size="x-small"
-                alternative-text="builder"
-                title="builder"
+                alternative-text="Skyline"
+                title="Skyline"
               ></lightning-icon>
             </span>
           </div>
@@ -128,6 +128,7 @@
           <a
             href="#"
             class="slds-builder-header__item-action slds-media slds-media_center"
+            onclick={handleSettingsClick}
           >
             <span class="slds-media__figure">
               <span
@@ -144,26 +145,6 @@
             <span class="slds-media__body">
               <span class="slds-truncate" title="Link">Settings</span>
             </span>
-          </a>
-        </div>
-        <div class="slds-builder-header__utilities-item">
-          <a
-            href="#"
-            class="slds-builder-header__item-action slds-media slds-media_center"
-          >
-            <div class="slds-media__figure">
-              <span
-                class="slds-icon_container slds-icon-utility-help slds-current-color"
-              >
-                <lightning-icon
-                  icon-name="utility:help"
-                  size="x-small"
-                  alternative-text="Help"
-                  title="Help"
-                ></lightning-icon>
-              </span>
-            </div>
-            <div class="slds-media__body">Help</div>
           </a>
         </div>
       </div>

--- a/extension/src/modules/s/header/header.ts
+++ b/extension/src/modules/s/header/header.ts
@@ -21,6 +21,7 @@
  */
 import { LightningElement, api } from "lwc";
 import { Pages } from "../app/app";
+import App from "../app/app";
 
 export default class Header extends LightningElement {
   showNavigation = false;
@@ -49,5 +50,15 @@ export default class Header extends LightningElement {
    */
   handleNavigationClick() {
     this.showNavigation = !this.showNavigation;
+  }
+
+  /**
+   * Handles clicks on the settings link.
+   * Opens the VSCode settings page for the Skyline extension.
+   */
+  handleSettingsClick(event: Event) {
+    App.sendMessage({
+      openSettings: true
+    });
   }
 }

--- a/extension/src/test/mocks/app.ts
+++ b/extension/src/test/mocks/app.ts
@@ -32,6 +32,9 @@ const mockVscode = {
 // Mock acquireVsCodeApi globally
 (global as any).acquireVsCodeApi = jest.fn(() => mockVscode);
 
+// Export mockVscode for tests to access
+export { mockVscode };
+
 /**
  * Enum representing the different pages within the application.
  */
@@ -131,6 +134,18 @@ export default class App extends LightningElement {
     return new Promise<ExecuteResult>((resolve) => {
       App.pendingResolvers.set(requestId, resolve);
     });
+  }
+
+  /**
+   * Sends a message to the VS Code extension without expecting a response.
+   * @param message The message to send.
+   */
+  static sendMessage(message: any): void {
+    App.vscode.postMessage(message);
+
+    if (App.isDebugMode()) {
+      console.log(`[DEBUG] Sending message:`, message);
+    }
   }
 
   /**

--- a/extension/src/test/mocks/header.ts
+++ b/extension/src/test/mocks/header.ts
@@ -50,4 +50,16 @@ export default class Header extends LightningElement {
   handleNavigationClick() {
     this.showNavigation = !this.showNavigation;
   }
+
+  /**
+   * Handles clicks on the settings link.
+   * Opens the VSCode settings page for the Skyline extension.
+   */
+  handleSettingsClick(event: Event) {
+    event.preventDefault();
+    const App = require("./app").default;
+    App.sendMessage({
+      openSettings: true
+    });
+  }
 }

--- a/extension/src/test/suite/app.test.ts
+++ b/extension/src/test/suite/app.test.ts
@@ -419,7 +419,7 @@ describe("App Component Tests", () => {
   describe("sendMessage Method", () => {
     it("should send message to VSCode without expecting response", () => {
       const message = { openSettings: true };
-      
+
       App.sendMessage(message);
 
       expect(mockVscode.postMessage).toHaveBeenCalledWith(message);
@@ -428,14 +428,17 @@ describe("App Component Tests", () => {
     it("should log message in debug mode", () => {
       // Enable debug mode
       mockWindow.vsCodeConfig.debugMode = true;
-      
+
       const message = { openSettings: true };
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
-      
+      const consoleSpy = jest.spyOn(console, "log").mockImplementation();
+
       App.sendMessage(message);
 
-      expect(consoleSpy).toHaveBeenCalledWith('[DEBUG] Sending message:', message);
-      
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[DEBUG] Sending message:",
+        message
+      );
+
       consoleSpy.mockRestore();
       mockWindow.vsCodeConfig.debugMode = false;
     });
@@ -443,25 +446,28 @@ describe("App Component Tests", () => {
     it("should not log message when debug mode is disabled", () => {
       // Ensure debug mode is disabled
       mockWindow.vsCodeConfig.debugMode = false;
-      
+
       const message = { openSettings: true };
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
-      
+      const consoleSpy = jest.spyOn(console, "log").mockImplementation();
+
       App.sendMessage(message);
 
-      expect(consoleSpy).not.toHaveBeenCalledWith('[DEBUG] Sending message:', expect.anything());
-      
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        "[DEBUG] Sending message:",
+        expect.anything()
+      );
+
       consoleSpy.mockRestore();
     });
 
     it("should handle different message types", () => {
       const messages = [
         { openSettings: true },
-        { command: 'test', data: 'value' },
-        { type: 'notification', message: 'test' }
+        { command: "test", data: "value" },
+        { type: "notification", message: "test" }
       ];
 
-      messages.forEach(message => {
+      messages.forEach((message) => {
         App.sendMessage(message);
         expect(mockVscode.postMessage).toHaveBeenCalledWith(message);
       });

--- a/extension/src/test/suite/app.test.ts
+++ b/extension/src/test/suite/app.test.ts
@@ -15,16 +15,12 @@
  */
 
 import App, { Pages, ExecuteResult } from "../../modules/s/app/app";
+import { mockVscode } from "../../test/mocks/app";
 
 // Mock uuid
 jest.mock("uuid", () => ({
   v4: jest.fn(() => "test-uuid-123")
 }));
-
-// Mock acquireVsCodeApi
-const mockVscode = {
-  postMessage: jest.fn()
-};
 
 // Mock window object
 const mockWindow = {
@@ -417,6 +413,60 @@ describe("App Component Tests", () => {
     it("should return false for showOrgManager when currentPage is not orgManager", () => {
       app.currentPage = Pages.home;
       expect(app.showOrgManager).toBe(false);
+    });
+  });
+
+  describe("sendMessage Method", () => {
+    it("should send message to VSCode without expecting response", () => {
+      const message = { openSettings: true };
+      
+      App.sendMessage(message);
+
+      expect(mockVscode.postMessage).toHaveBeenCalledWith(message);
+    });
+
+    it("should log message in debug mode", () => {
+      // Enable debug mode
+      mockWindow.vsCodeConfig.debugMode = true;
+      
+      const message = { openSettings: true };
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      
+      App.sendMessage(message);
+
+      expect(consoleSpy).toHaveBeenCalledWith('[DEBUG] Sending message:', message);
+      
+      consoleSpy.mockRestore();
+      mockWindow.vsCodeConfig.debugMode = false;
+    });
+
+    it("should not log message when debug mode is disabled", () => {
+      // Ensure debug mode is disabled
+      mockWindow.vsCodeConfig.debugMode = false;
+      
+      const message = { openSettings: true };
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      
+      App.sendMessage(message);
+
+      expect(consoleSpy).not.toHaveBeenCalledWith('[DEBUG] Sending message:', expect.anything());
+      
+      consoleSpy.mockRestore();
+    });
+
+    it("should handle different message types", () => {
+      const messages = [
+        { openSettings: true },
+        { command: 'test', data: 'value' },
+        { type: 'notification', message: 'test' }
+      ];
+
+      messages.forEach(message => {
+        App.sendMessage(message);
+        expect(mockVscode.postMessage).toHaveBeenCalledWith(message);
+      });
+
+      expect(mockVscode.postMessage).toHaveBeenCalledTimes(messages.length);
     });
   });
 

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -67,6 +67,7 @@ describe("Extension Tests", () => {
     (vscode.commands.registerCommand as jest.Mock).mockReturnValue({
       dispose: jest.fn()
     });
+    (vscode.commands.executeCommand as jest.Mock) = jest.fn().mockResolvedValue(undefined);
     (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
       debugMode: false
     });
@@ -107,7 +108,8 @@ describe("Extension Tests", () => {
         vscode.ViewColumn.One,
         {
           enableScripts: true,
-          retainContextWhenHidden: true
+          retainContextWhenHidden: true,
+          localResourceRoots: [mockContext.extensionUri]
         }
       );
     });
@@ -323,6 +325,53 @@ describe("Extension Tests", () => {
 
       const html = mockPanel.webview.html;
       expect(html).toContain("debugMode");
+    });
+  });
+
+  describe("Settings Functionality", () => {
+    it("should handle openSettings message and execute command", () => {
+      activate(mockContext);
+
+      const commandCallback = (vscode.commands.registerCommand as jest.Mock)
+        .mock.calls[0][1];
+      commandCallback();
+
+      const messageCallback = (mockWebview.onDidReceiveMessage as jest.Mock)
+        .mock.calls[0][0];
+
+      const testMessage = {
+        openSettings: true
+      };
+
+      messageCallback(testMessage);
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'workbench.action.openSettings',
+        '@ext:mitchspano.skyline-devops'
+      );
+    });
+
+    it("should not execute command for non-settings messages", () => {
+      activate(mockContext);
+
+      const commandCallback = (vscode.commands.registerCommand as jest.Mock)
+        .mock.calls[0][1];
+      commandCallback();
+
+      const messageCallback = (mockWebview.onDidReceiveMessage as jest.Mock)
+        .mock.calls[0][0];
+
+      const testMessage = {
+        command: "test-command",
+        elementId: "test-element"
+      };
+
+      messageCallback(testMessage);
+
+      expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith(
+        'workbench.action.openSettings',
+        expect.any(String)
+      );
     });
   });
 

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -67,7 +67,9 @@ describe("Extension Tests", () => {
     (vscode.commands.registerCommand as jest.Mock).mockReturnValue({
       dispose: jest.fn()
     });
-    (vscode.commands.executeCommand as jest.Mock) = jest.fn().mockResolvedValue(undefined);
+    (vscode.commands.executeCommand as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue(undefined);
     (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
       debugMode: false
     });
@@ -346,8 +348,8 @@ describe("Extension Tests", () => {
       messageCallback(testMessage);
 
       expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
-        'workbench.action.openSettings',
-        '@ext:mitchspano.skyline-devops'
+        "workbench.action.openSettings",
+        "@ext:mitchspano.skyline-devops"
       );
     });
 
@@ -369,7 +371,7 @@ describe("Extension Tests", () => {
       messageCallback(testMessage);
 
       expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith(
-        'workbench.action.openSettings',
+        "workbench.action.openSettings",
         expect.any(String)
       );
     });

--- a/extension/src/test/suite/header.test.ts
+++ b/extension/src/test/suite/header.test.ts
@@ -32,7 +32,7 @@ describe("Header Tests", () => {
   beforeEach(() => {
     // Reset mocks
     jest.clearAllMocks();
-    
+
     // Create a new instance of Header for each test
     header = new Header();
   });
@@ -390,7 +390,7 @@ describe("Header Tests", () => {
   describe("handleSettingsClick", () => {
     it("should have handleSettingsClick method", () => {
       // Assert
-      expect(typeof header.handleSettingsClick).toBe('function');
+      expect(typeof header.handleSettingsClick).toBe("function");
     });
 
     it("should call App.sendMessage with openSettings message", () => {

--- a/extension/src/test/suite/header.test.ts
+++ b/extension/src/test/suite/header.test.ts
@@ -17,10 +17,22 @@
 import Header from "../../modules/s/header/header";
 import { Pages } from "../../modules/s/app/app";
 
+// Mock the App module
+jest.mock("../../modules/s/app/app", () => ({
+  ...jest.requireActual("../../modules/s/app/app"),
+  default: {
+    ...jest.requireActual("../../modules/s/app/app").default,
+    sendMessage: jest.fn()
+  }
+}));
+
 describe("Header Tests", () => {
   let header: Header;
 
   beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks();
+    
     // Create a new instance of Header for each test
     header = new Header();
   });
@@ -372,6 +384,84 @@ describe("Header Tests", () => {
 
       // Verify total calls
       expect(dispatchEventSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("handleSettingsClick", () => {
+    it("should have handleSettingsClick method", () => {
+      // Assert
+      expect(typeof header.handleSettingsClick).toBe('function');
+    });
+
+    it("should call App.sendMessage with openSettings message", () => {
+      // Arrange
+      const mockEvent = {
+        preventDefault: jest.fn()
+      } as unknown as Event;
+
+      // Get the mocked App
+      const App = require("../../modules/s/app/app").default;
+
+      // Act
+      header.handleSettingsClick(mockEvent);
+
+      // Assert
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(App.sendMessage).toHaveBeenCalledWith({
+        openSettings: true
+      });
+    });
+
+    it("should prevent default link behavior", () => {
+      // Arrange
+      const mockEvent = {
+        preventDefault: jest.fn()
+      } as unknown as Event;
+
+      // Act
+      header.handleSettingsClick(mockEvent);
+
+      // Assert
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should send correct message format", () => {
+      // Arrange
+      const mockEvent = {
+        preventDefault: jest.fn()
+      } as unknown as Event;
+
+      // Get the mocked App
+      const App = require("../../modules/s/app/app").default;
+
+      // Act
+      header.handleSettingsClick(mockEvent);
+
+      // Assert
+      expect(App.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          openSettings: true
+        })
+      );
+    });
+
+    it("should handle multiple settings clicks", () => {
+      // Arrange
+      const mockEvent = {
+        preventDefault: jest.fn()
+      } as unknown as Event;
+
+      // Get the mocked App
+      const App = require("../../modules/s/app/app").default;
+
+      // Act
+      header.handleSettingsClick(mockEvent);
+      header.handleSettingsClick(mockEvent);
+      header.handleSettingsClick(mockEvent);
+
+      // Assert
+      expect(App.sendMessage).toHaveBeenCalledTimes(3);
+      expect(mockEvent.preventDefault).toHaveBeenCalledTimes(3);
     });
   });
 


### PR DESCRIPTION
Enables the "Settings" link  on the header to open VSCode settings for the extension.
Removes unnecessary "Help" link.

Fixes #13